### PR TITLE
Add FTP deployment workflow for shared hosting

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,42 @@
+name: Deploy to Shared Hosting (FTP)
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.3'
+          coverage: none
+
+      - name: Install dependencies
+        run: composer install --no-dev --prefer-dist --optimize-autoloader
+
+      - name: Deploy via FTP
+        uses: SamKirkland/FTP-Deploy-Action@v4.3.5
+        with:
+          server: ${{ secrets.FTP_SERVER }}
+          username: ${{ secrets.FTP_USER }}
+          password: ${{ secrets.FTP_PASS }}
+          protocol: ftps
+          port: 21
+          local-dir: ./
+          server-dir: /public_html/lab/echodb/
+          exclude: |
+            **/.git*
+            **/.github*
+            **/node_modules/**
+            **/tests/**
+            **/sql/**
+            **/docs/**
+            **/*.yml

--- a/index.php
+++ b/index.php
@@ -1,0 +1,3 @@
+<?php
+
+require __DIR__ . '/public/index.php';


### PR DESCRIPTION
## Summary
- add a GitHub Actions workflow to deploy the project to shared hosting via FTPS
- install PHP dependencies during the workflow to include the vendor directory before upload
- add a root-level index.php that proxies to the public front controller for shared hosting compatibility

## Testing
- composer validate

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69149b38146c832ea254bd8518509696)