### PR TITLE
Support base path deployments and slim FTP uploads

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -22,7 +22,25 @@ jobs:
       - name: Install dependencies locally
         if: ${{ !contains(github.event.head_commit.message, '[skip-composer]') }}
         run: composer install --no-dev --prefer-dist --optimize-autoloader
-      
+
+      - name: Prepare deployment bundle
+        run: |
+          rm -rf deploy
+          mkdir deploy
+          rsync -a \
+            --delete \
+            --prune-empty-dirs \
+            --include='index.php' \
+            --include='composer.json' \
+            --include='composer.lock' \
+            --include='.env.example' \
+            --include='config/***' \
+            --include='public/***' \
+            --include='src/***' \
+            --include='vendor/***' \
+            --exclude='*' \
+            ./ deploy
+
       - name: Deploy via FTP
         uses: SamKirkland/FTP-Deploy-Action@v4.3.5
         with:
@@ -31,7 +49,7 @@ jobs:
           password: ${{ secrets.FTP_PASS }}
           protocol: ftps
           port: 21
-          local-dir: ./
+          local-dir: ./deploy/
           server-dir: /public_html/lab/echodb/
           exclude: |
             **/.git*

--- a/config/config.sample.php
+++ b/config/config.sample.php
@@ -5,6 +5,7 @@ return [
     'app_version' => '1.0.0',
     'environment' => 'production',
     'display_errors' => false,
+    'base_path' => '',
     'db' => [
         'host' => '127.0.0.1',
         'port' => 3306,

--- a/public/api/index.php
+++ b/public/api/index.php
@@ -4,12 +4,14 @@ declare(strict_types=1);
 
 use App\Bootstrap;
 use App\Router;
+use App\Support\PathResolver;
 
 require_once __DIR__ . '/../../vendor/autoload.php';
 
 $bootstrap = Bootstrap::getInstance();
-$router = new Router();
 $config = $bootstrap->getConfig();
+$basePath = PathResolver::resolveBasePath($config['base_path'] ?? null, $_SERVER['SCRIPT_NAME'] ?? null);
+$router = new Router($basePath);
 $database = $bootstrap->getDatabase();
 
 $origin = $_SERVER['HTTP_ORIGIN'] ?? null;

--- a/src/Bootstrap.php
+++ b/src/Bootstrap.php
@@ -73,6 +73,11 @@ class Bootstrap
             FILTER_VALIDATE_BOOL
         );
 
+        $configuredBasePath = getenv('APP_BASE_PATH');
+        if ($configuredBasePath !== false) {
+            $config['base_path'] = (string) $configuredBasePath;
+        }
+
         $config['db'] = [
             'host' => getenv('DB_HOST') ?: $config['db']['host'],
             'port' => (int) (getenv('DB_PORT') ?: $config['db']['port']),

--- a/src/Support/PathResolver.php
+++ b/src/Support/PathResolver.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Support;
+
+final class PathResolver
+{
+    public static function resolveBasePath(?string $configuredPath, ?string $scriptName = null): string
+    {
+        $normalizedConfigured = self::normalize($configuredPath);
+        if ($normalizedConfigured !== '') {
+            return $normalizedConfigured;
+        }
+
+        return self::normalizeFromScript($scriptName ?? ($_SERVER['SCRIPT_NAME'] ?? ''));
+    }
+
+    private static function normalize(?string $path): string
+    {
+        if ($path === null) {
+            return '';
+        }
+
+        $trimmed = trim($path);
+        if ($trimmed === '' || $trimmed === '/') {
+            return '';
+        }
+
+        return '/' . trim($trimmed, '/');
+    }
+
+    private static function normalizeFromScript(?string $scriptName): string
+    {
+        if ($scriptName === null || $scriptName === '') {
+            return '';
+        }
+
+        $directory = str_replace('\\', '/', dirname($scriptName));
+        if ($directory === '.' || $directory === '/') {
+            return '';
+        }
+
+        if (preg_match('#/api$#', $directory) === 1) {
+            $directory = dirname($directory);
+        }
+
+        if ($directory === '.' || $directory === '/' || $directory === '') {
+            return '';
+        }
+
+        return '/' . trim($directory, '/');
+    }
+}


### PR DESCRIPTION
## Summary
- add a PathResolver utility and update the frontend entrypoint to honour subdirectory base paths for assets and API calls
- make the API router aware of the configured base path so routes resolve correctly when hosted under lab.minischetti.org/echodb
- prepare a minimal deployment bundle in the GitHub Action before pushing files to Namecheap shared hosting

## Testing
- php -l public/index.php
- php -l public/api/index.php
- php -l src/Router.php
- php -l src/Support/PathResolver.php
- php -l src/Bootstrap.php

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6914a7a86d0c832ea788991f130eee34)