### PR TITLE
Add server error logging for API routes

### DIFF
--- a/public/api/index.php
+++ b/public/api/index.php
@@ -11,7 +11,7 @@ require_once __DIR__ . '/../../vendor/autoload.php';
 $bootstrap = Bootstrap::getInstance();
 $config = $bootstrap->getConfig();
 $basePath = PathResolver::resolveBasePath($config['base_path'] ?? null, $_SERVER['SCRIPT_NAME'] ?? null);
-$router = new Router($basePath);
+$router = new Router($basePath, $bootstrap->getLogger());
 $database = $bootstrap->getDatabase();
 
 $origin = $_SERVER['HTTP_ORIGIN'] ?? null;


### PR DESCRIPTION
## Summary
- capture unhandled exceptions during route dispatch and return a JSON 500 response
- pass the application logger into the router so errors are written to the log file

## Testing
- php -l src/Router.php
- php -l public/api/index.php

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6914b20dbccc832ea852e89f2784afb5)