### PR TITLE
Refactor bootstrap paths for shared hosting deployment

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -28,11 +28,15 @@ jobs:
           rm -rf deploy
           mkdir deploy
 
-          # Copy the entire project except .git and the deploy folder itself
+          # Copy the entire project except CI/VCS/build artifacts
           rsync -a \
             --exclude='.git/' \
             --exclude='.github/' \
             --exclude='deploy/' \
+            --exclude='node_modules/' \
+            --exclude='sql/' \
+            --exclude='tests/' \
+            --exclude='docs/' \
             ./ ./deploy/
 
           # Flatten public/ into deploy root
@@ -57,5 +61,6 @@ jobs:
             **/node_modules/**
             **/tests/**
             **/sql/**
-            **/*.yml
+            **/docs/**
+            **/deploy/**
 

--- a/public/api/index.php
+++ b/public/api/index.php
@@ -4,9 +4,37 @@ declare(strict_types=1);
 
 use App\Bootstrap;
 use App\Router;
+use App\Support\BootstrapPaths;
 use App\Support\PathResolver;
 
-require_once __DIR__ . '/../../vendor/autoload.php';
+$projectRoot = realpath(__DIR__ . '/../../');
+if ($projectRoot === false || !is_dir($projectRoot . '/vendor')) {
+    $projectRoot = realpath(__DIR__ . '/..');
+    if ($projectRoot === false || !is_dir($projectRoot . '/vendor')) {
+        $projectRoot = __DIR__;
+    }
+}
+
+$bootstrapPathsFile = $projectRoot . '/src/Support/BootstrapPaths.php';
+if (!file_exists($bootstrapPathsFile)) {
+    http_response_code(500);
+    echo 'Fatal error: Bootstrap path resolver not found.';
+    exit;
+}
+
+require_once $bootstrapPathsFile;
+
+$autoload = BootstrapPaths::resolve('vendor/autoload.php');
+
+if (!file_exists($autoload)) {
+    http_response_code(500);
+    echo 'Fatal error: vendor/autoload.php not found.';
+    exit;
+}
+
+require_once $autoload;
+
+require_once BootstrapPaths::resolve('src/Bootstrap.php');
 
 $bootstrap = Bootstrap::getInstance();
 $config = $bootstrap->getConfig();

--- a/public/index.php
+++ b/public/index.php
@@ -3,9 +3,34 @@
 declare(strict_types=1);
 
 use App\Bootstrap;
+use App\Support\BootstrapPaths;
 use App\Support\PathResolver;
 
-require_once __DIR__ . '/../vendor/autoload.php';
+$projectRoot = realpath(__DIR__ . '/..');
+if ($projectRoot === false || !is_dir($projectRoot . '/vendor')) {
+    $projectRoot = __DIR__;
+}
+
+$bootstrapPathsFile = $projectRoot . '/src/Support/BootstrapPaths.php';
+if (!file_exists($bootstrapPathsFile)) {
+    http_response_code(500);
+    echo 'Fatal error: Bootstrap path resolver not found.';
+    exit;
+}
+
+require_once $bootstrapPathsFile;
+
+$autoload = BootstrapPaths::resolve('vendor/autoload.php');
+
+if (!file_exists($autoload)) {
+    http_response_code(500);
+    echo 'Fatal error: vendor/autoload.php not found.';
+    exit;
+}
+
+require_once $autoload;
+
+require_once BootstrapPaths::resolve('src/Bootstrap.php');
 
 $bootstrap = Bootstrap::getInstance();
 $config = $bootstrap->getConfig();

--- a/src/Support/BootstrapPaths.php
+++ b/src/Support/BootstrapPaths.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Support;
+
+final class BootstrapPaths
+{
+    public static function projectRoot(): string
+    {
+        $root = realpath(__DIR__ . '/../../');
+
+        if ($root === false) {
+            throw new \RuntimeException('Unable to determine project root path.');
+        }
+
+        return $root;
+    }
+
+    public static function resolve(string $path): string
+    {
+        return self::projectRoot() . '/' . ltrim($path, '/');
+    }
+}


### PR DESCRIPTION
## Summary
- add a BootstrapPaths helper to resolve project-rooted paths reliably
- update the web and API front controllers to load dependencies via the new resolver
- adjust the deployment workflow to flatten public/ assets while excluding non-deployable artifacts

## Testing
- php -l public/index.php
- php -l public/api/index.php
