### PR TITLE
Make ECHOdb interface mobile-first responsive

### DIFF
--- a/public/css/style.css
+++ b/public/css/style.css
@@ -1,3 +1,11 @@
+/* Responsive audit notes:
+- Body currently sets overflow-x: hidden, preventing horizontal scrolling for dense data views on small screens.
+- The site header navigation stays in a single horizontal row with wide gaps, which can overflow narrow widths.
+- Section and hero panels assume large horizontal padding and max widths (~1120px) without a centered container wrapper.
+- Demo grid and architecture diagram default to multi-column layouts that collapse awkwardly on phones.
+- Footer layout relies on a three-column grid and sticky positioning that struggles on compact viewports.
+*/
+
 :root {
     color-scheme: dark;
     --bg-start: #090b11;
@@ -72,7 +80,6 @@ body {
     display: flex;
     flex-direction: column;
     position: relative;
-    overflow-x: hidden;
 }
 
 body.theme-dark {
@@ -123,6 +130,14 @@ body.theme-dark::after {
 
 main {
     flex: 1;
+    display: grid;
+    gap: clamp(3rem, 5vw, 5.5rem);
+    padding: clamp(3rem, 6vw, 5rem) 1.25rem clamp(5rem, 8vw, 6rem);
+}
+
+main > section {
+    width: min(100%, 1200px);
+    margin: 0 auto;
 }
 
 .site-header {
@@ -130,22 +145,25 @@ main {
     top: 0;
     z-index: 40;
     display: flex;
-    align-items: center;
-    justify-content: space-between;
-    padding: 1.1rem clamp(1.5rem, 4vw, 4rem);
+    flex-direction: column;
+    align-items: stretch;
+    gap: 0.75rem;
+    padding: 1rem 1.25rem;
     backdrop-filter: blur(18px);
-    background: linear-gradient(180deg, rgba(9, 13, 19, 0.72), rgba(9, 13, 19, 0));
+    background: linear-gradient(180deg, rgba(9, 13, 19, 0.85), rgba(9, 13, 19, 0));
     border-bottom: 1px solid rgba(255, 255, 255, 0.06);
 }
 
 .brand {
     display: inline-flex;
     align-items: center;
+    justify-content: center;
     gap: 0.75rem;
     color: inherit;
     text-decoration: none;
     font-weight: 600;
     letter-spacing: 0.04em;
+    width: 100%;
 }
 
 .brand-mark {
@@ -160,8 +178,12 @@ main {
 
 .site-nav {
     display: flex;
-    gap: clamp(1.2rem, 2.4vw, 2.4rem);
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 0.75rem;
     font-size: 0.95rem;
+    justify-content: center;
+    width: 100%;
 }
 
 .site-nav a {
@@ -172,6 +194,8 @@ main {
     font-weight: 500;
     position: relative;
     transition: color var(--transition);
+    padding: 0.4rem 0.65rem;
+    border-radius: 999px;
 }
 
 .site-nav a::after {
@@ -198,16 +222,19 @@ main {
 }
 
 .hero {
-    min-height: 100vh;
+    min-height: min(100vh, 840px);
     display: grid;
     place-items: center;
-    padding: clamp(4rem, 8vh, 7rem) clamp(1.5rem, 5vw, 6rem) clamp(6rem, 12vh, 9rem);
+    padding: clamp(3.5rem, 8vh, 5.5rem) 0 clamp(4.5rem, 12vh, 7rem);
+    width: 100%;
 }
 
 .hero-panel {
     position: relative;
-    width: min(100%, 1120px);
-    padding: clamp(2.8rem, 6vw, 4.6rem);
+    width: 100%;
+    max-width: 1120px;
+    margin: 0 auto;
+    padding: clamp(2.4rem, 6vw, 4.2rem);
     overflow: hidden;
     display: grid;
     gap: 2.4rem;
@@ -310,9 +337,12 @@ main {
 }
 
 .hero-actions {
-    display: flex;
-    gap: 1rem;
-    flex-wrap: wrap;
+    display: grid;
+    gap: 0.75rem;
+}
+
+.hero-actions .button {
+    width: 100%;
 }
 
 .button {
@@ -439,9 +469,9 @@ main {
 }
 
 .section {
-    padding: clamp(4rem, 8vh, 6rem) clamp(1.5rem, 5vw, 6rem);
+    padding: clamp(2.75rem, 6vw, 3.5rem) clamp(1.25rem, 4vw, 2.75rem);
     display: grid;
-    gap: 2.8rem;
+    gap: clamp(2rem, 4vw, 3rem);
     position: relative;
     z-index: 0;
 }
@@ -464,11 +494,9 @@ main {
 }
 
 .section-heading {
-    display: flex;
-    flex-wrap: wrap;
-    align-items: center;
-    gap: 1.5rem;
-    justify-content: space-between;
+    display: grid;
+    gap: 1rem;
+    align-items: flex-start;
 }
 
 .section-heading h2 {
@@ -480,13 +508,13 @@ main {
 .section-heading p {
     margin: 0;
     color: var(--text-soft);
-    max-width: 480px;
+    max-width: clamp(35ch, 70vw, 60ch);
     line-height: 1.6;
 }
 
 .demo-grid {
     display: grid;
-    grid-template-columns: repeat(2, minmax(0, 1fr));
+    grid-template-columns: 1fr;
     gap: clamp(1.5rem, 3vw, 2.5rem);
 }
 
@@ -552,7 +580,7 @@ main {
 
 textarea {
     width: 100%;
-    min-height: 260px;
+    min-height: clamp(220px, 40vh, 320px);
     border-radius: var(--radius-md);
     border: 1px solid rgba(255, 255, 255, 0.14);
     background: rgba(10, 15, 24, 0.4);
@@ -681,10 +709,8 @@ body.theme-light .node {
 }
 
 .panel-heading {
-    display: flex;
-    align-items: baseline;
-    justify-content: space-between;
-    gap: 0.5rem;
+    display: grid;
+    gap: 0.35rem;
 }
 
 .panel-heading h4 {
@@ -706,8 +732,9 @@ body.theme-light .node {
     padding: 0;
     display: grid;
     gap: 1rem;
-    max-height: 280px;
+    max-height: min(320px, 55vh);
     overflow-y: auto;
+    padding-right: 0.4rem;
 }
 
 .timeline li {
@@ -781,7 +808,7 @@ body.theme-light .node {
 
 .architecture-diagram {
     display: grid;
-    grid-template-columns: repeat(5, minmax(0, 1fr));
+    grid-template-columns: 1fr;
     align-items: center;
     gap: 1rem;
 }
@@ -812,7 +839,7 @@ body.theme-light .node {
     color: var(--text-soft);
     font-size: 0.75rem;
     line-height: 1.4;
-    width: max(160px, 16ch);
+    width: min(260px, 80vw);
     opacity: 0;
     pointer-events: none;
     transition: opacity var(--transition), transform var(--transition);
@@ -825,6 +852,7 @@ body.theme-light .node {
 }
 
 .arch-link {
+    display: none;
     height: 1px;
     background: linear-gradient(90deg, rgba(79, 195, 247, 0.4), rgba(128, 203, 196, 0.4));
     box-shadow: 0 0 20px rgba(79, 195, 247, 0.2);
@@ -859,11 +887,14 @@ body.theme-light .node {
 }
 
 .tabs {
-    display: inline-flex;
-    gap: 0.8rem;
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: center;
+    gap: 0.6rem;
     background: rgba(9, 13, 19, 0.4);
     border-radius: 999px;
     padding: 0.4rem;
+    width: 100%;
 }
 
 .docs .tabs {
@@ -882,6 +913,7 @@ body.theme-light .node {
     text-transform: uppercase;
     cursor: pointer;
     transition: background var(--transition), color var(--transition);
+    flex: 1 1 140px;
 }
 
 .tab-button.active {
@@ -966,6 +998,43 @@ pre {
     color: var(--text-strong);
 }
 
+.table-scroll {
+    width: 100%;
+    overflow-x: auto;
+    overflow-y: auto;
+    max-height: min(420px, 70vh);
+    -webkit-overflow-scrolling: touch;
+    border-radius: var(--radius-md);
+    border: 1px solid var(--glass-border);
+    background: rgba(6, 9, 14, 0.4);
+}
+
+.table-scroll table {
+    width: 100%;
+    border-collapse: collapse;
+    min-width: 560px;
+}
+
+.table-scroll th,
+.table-scroll td {
+    padding: 0.6rem 0.8rem;
+    text-align: left;
+    font-size: 0.85rem;
+    color: var(--text-soft);
+    border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.table-scroll th {
+    font-size: 0.75rem;
+    letter-spacing: 0.12em;
+    text-transform: uppercase;
+    color: var(--text-muted);
+    position: sticky;
+    top: 0;
+    background: rgba(9, 13, 19, 0.9);
+    backdrop-filter: blur(12px);
+}
+
 .sr-only {
     position: absolute;
     width: 1px;
@@ -1009,24 +1078,23 @@ pre {
 }
 
 .site-footer {
-    position: sticky;
-    bottom: 0;
+    margin-top: clamp(3rem, 7vw, 5rem);
     display: grid;
-    grid-template-columns: repeat(3, minmax(0, 1fr));
-    align-items: center;
-    padding: 1rem clamp(1.5rem, 5vw, 4rem);
-    background: rgba(9, 13, 19, 0.6);
+    gap: 1.5rem;
+    justify-items: center;
+    padding: 2.5rem 1.5rem 3rem;
+    background: rgba(9, 13, 19, 0.68);
     backdrop-filter: blur(15px);
     border-top: 1px solid rgba(255, 255, 255, 0.1);
-    font-size: 0.85rem;
+    font-size: 0.9rem;
     color: var(--text-muted);
-    z-index: 30;
 }
 
 .footer-links {
     display: flex;
     justify-content: center;
     gap: 1.2rem;
+    flex-wrap: wrap;
 }
 
 .footer-links a {
@@ -1053,10 +1121,24 @@ pre {
     border-color: rgba(79, 195, 247, 0.6);
 }
 
+.footer-copy {
+    display: grid;
+    gap: 0.5rem;
+    text-align: center;
+    max-width: 60ch;
+}
+
+.footer-copy p {
+    margin: 0;
+    color: var(--text-soft);
+    line-height: 1.6;
+}
+
 .footer-controls {
-    justify-self: end;
     display: flex;
     gap: 0.75rem;
+    flex-wrap: wrap;
+    justify-content: center;
 }
 
 [data-animate] {
@@ -1071,86 +1153,122 @@ pre {
     transform: translateY(0);
 }
 
-@media (max-width: 1100px) {
-    .demo-grid {
-        grid-template-columns: 1fr;
-    }
-
-    .architecture-diagram {
-        grid-template-columns: repeat(3, minmax(0, 1fr));
-        gap: 1.5rem;
-    }
-
-    .arch-link {
-        display: none;
-    }
-}
-
-@media (max-width: 900px) {
+/* Responsive breakpoints */
+@media (min-width: 640px) {
     .site-header {
-        flex-direction: column;
-        gap: 1rem;
-        align-items: flex-start;
+        flex-direction: row;
+        align-items: center;
+        justify-content: space-between;
+        padding-inline: clamp(1.5rem, 6vw, 3rem);
+    }
+
+    .brand {
+        width: auto;
+        justify-content: flex-start;
     }
 
     .site-nav {
-        width: 100%;
-        justify-content: space-between;
-    }
-
-    .hero {
-        padding-top: 5.5rem;
-    }
-
-    .hero-panel {
-        padding: clamp(2.4rem, 7vw, 3.4rem);
-    }
-
-    .site-footer {
-        grid-template-columns: 1fr;
-        gap: 1rem;
-        text-align: center;
-    }
-
-    .footer-controls {
-        justify-self: center;
-    }
-}
-
-@media (max-width: 720px) {
-    .hero-meta {
-        grid-template-columns: 1fr;
+        gap: clamp(1rem, 2.4vw, 1.75rem);
+        width: auto;
+        justify-content: flex-end;
     }
 
     .hero-actions {
-        width: 100%;
+        grid-auto-flow: column;
+        grid-auto-columns: minmax(0, 1fr);
     }
 
     .hero-actions .button {
-        flex: 1;
         justify-content: center;
     }
 
-    textarea {
-        min-height: 220px;
+    .editor-actions {
+        justify-content: flex-start;
+    }
+}
+
+@media (min-width: 768px) {
+    main {
+        padding-inline: clamp(2rem, 6vw, 3rem);
     }
 
-    .timeline {
-        max-height: 220px;
+    .section-heading {
+        grid-template-columns: minmax(0, 1fr) auto;
+        align-items: center;
+    }
+
+    .hero {
+        padding-inline: 0;
+    }
+
+    .hero-actions {
+        gap: 1rem;
+    }
+
+    .panel-heading {
+        grid-template-columns: repeat(2, minmax(0, auto));
+        align-items: baseline;
+    }
+
+    .demo-controls {
+        justify-content: center;
+    }
+}
+
+@media (min-width: 1024px) {
+    .demo-grid {
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+        align-items: start;
+    }
+
+    .hero-actions {
+        grid-auto-flow: column;
+        grid-auto-columns: auto;
+        justify-content: start;
+    }
+
+    .hero-actions .button {
+        min-width: 0;
+        width: auto;
     }
 
     .architecture-diagram {
-        grid-template-columns: 1fr;
+        grid-template-columns: repeat(5, minmax(0, 1fr));
+        gap: 1.25rem;
     }
 
-    .tabs {
-        width: 100%;
-        justify-content: center;
+    .arch-link {
+        display: block;
     }
 
-    .tab-button {
-        flex: 1;
-        text-align: center;
+    .site-footer {
+        justify-items: stretch;
+        text-align: left;
+        grid-template-columns: repeat(3, minmax(0, 1fr));
+        align-items: center;
+        padding-inline: clamp(2.5rem, 6vw, 4rem);
+    }
+
+    .footer-copy {
+        text-align: left;
+    }
+
+    .footer-controls {
+        justify-content: flex-end;
+    }
+}
+
+@media (min-width: 1280px) {
+    main > section {
+        width: min(100%, 1280px);
+    }
+
+    .hero-panel {
+        padding: clamp(2.8rem, 5vw, 4.6rem);
+    }
+
+    .section {
+        padding: clamp(3rem, 5vw, 3.75rem) clamp(2rem, 4vw, 3.25rem);
     }
 }
 


### PR DESCRIPTION
## Summary
- reorganize the global layout with a mobile-first grid, centered sections, and flexible hero/header spacing
- simplify component defaults so cards, demo grids, and architecture diagrams stack cleanly before expanding at larger breakpoints
- add reusable data-scroll styling and dark-themed footer/typography refinements alongside min-width breakpoint tiers

## Testing
- not run (UI-only change)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691690f30f04832eb46da7b85c24bba7)