### PR TITLE
Prevent duplicate insert mutations

### DIFF
--- a/src/EventStore.php
+++ b/src/EventStore.php
@@ -54,6 +54,10 @@ class EventStore
         $changes = $this->sanitizeChanges($table, $changes, $type);
 
         $existingRow = $this->fetchRow($table, $rowId);
+        if ($type === 'insert' && $existingRow !== null) {
+            throw new InvalidArgumentException('Row already exists. Choose a different row_id or use an update mutation.');
+        }
+
         if ($existingRow === null && $type !== 'insert') {
             throw new InvalidArgumentException('Target row not found.');
         }


### PR DESCRIPTION
## Summary
- guard against inserting events for rows that already exist so the API returns a clear validation error instead of a SQL constraint violation

## Testing
- php -l src/EventStore.php

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69169c64b604832e86e3cb16c855a1e3)