### PR TITLE
Improve mobile audio unlocking

### DIFF
--- a/public/js/main.js
+++ b/public/js/main.js
@@ -87,6 +87,7 @@ function init() {
     bindDemoControls();
     bindThemeToggles();
     bindSoundToggles();
+    bindSoundUnlock();
     bindTabs();
     bindCopyButtons();
     observeAnimations();
@@ -412,6 +413,31 @@ function bindSoundToggles() {
             updateSoundButtons(enabled);
         });
     });
+}
+
+function bindSoundUnlock() {
+    const unlockEvents = ['pointerdown', 'touchstart', 'click', 'keydown'];
+
+    function cleanup() {
+        unlockEvents.forEach((event) => {
+            window.removeEventListener(event, attemptUnlock);
+        });
+        document.removeEventListener('visibilitychange', attemptUnlock);
+    }
+
+    function attemptUnlock() {
+        Promise.resolve(soundBoard.unlock()).then((success) => {
+            if (success) {
+                cleanup();
+            }
+        });
+    }
+
+    unlockEvents.forEach((event) => {
+        window.addEventListener(event, attemptUnlock, { passive: true });
+    });
+
+    document.addEventListener('visibilitychange', attemptUnlock);
 }
 
 function updateSoundButtons(enabled) {


### PR DESCRIPTION
## Summary
- guard audio context creation with a priming flow that resumes the context and plays a silent buffer the first time it is unlocked
- listen for the first user interaction on the page to trigger the unlock so mobile browsers can play SSE-driven sounds

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6916a7709b94832eb5889e8066c0fffd)